### PR TITLE
Support 'stop' / err on unrecognized option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,8 @@ fn run_action(action: &str) -> Result<String, String> {
         player.checked_previous().map_err(|e| format!("Could not control player: {}", e))?;
     } else if action == "stop" {
         player.checked_stop().map_err(|e| format!("Could not control player: {}", e))?;
+    } else {
+        return Err(format!("Unrecognized option: {}", action));
     }
 
     Ok(format!("Action {} run", action))

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,8 @@ fn run_action(action: &str) -> Result<String, String> {
         player.checked_next().map_err(|e| format!("Could not control player: {}", e))?;
     } else if action == "previous" {
         player.checked_previous().map_err(|e| format!("Could not control player: {}", e))?;
+    } else if action == "stop" {
+        player.checked_stop().map_err(|e| format!("Could not control player: {}", e))?;
     }
 
     Ok(format!("Action {} run", action))


### PR DESCRIPTION
This PR adds two things:

* Ability to use `mpris-control stop` 
* An error message if you use an unrecognized command